### PR TITLE
docs: adjustments to `README.md` and `LICENSE` missing file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 sherlocklima
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -14,21 +14,23 @@ To install the package, use npm:
 
 ```sh
 npm install pg-sql-factory
+```
 
-
-Configuration
+## Configuration
 Create a .env file in the root of your project and configure the following environment variables:
 
+```sh
 DB_HOST=your-postgresql-host
 DB_USER=your-postgresql-user
 DB_PASSWORD=your-postgresql-password
 DB_DATABASE=your-postgresql-database
 DB_PORT=5432
+```
 
-
-Usage
+## Usage
 Here's an example of how to use the pg-sql-factory Package:
 
+```js
 import { initializeDatabase } from './utils/database';
 import { createUsers } from './services/userService';
 
@@ -55,10 +57,10 @@ const main = async () => {
 };
 
 main();
+```
 
-
-Contributing
+## Contributing
 Feel free to open issues or submit pull requests with improvements. Contributions are always welcome!
 
-License
+## License
 This project is licensed under the MIT License. See the LICENSE file for more details.


### PR DESCRIPTION
Fixes formatting issues with `README.md` and adds in a missing `LICENSE` file. 

Best of luck on merging this!